### PR TITLE
Update code path

### DIFF
--- a/Assignments/08-10_Compile-BufferStockTheory-Paper/Compile-BufferStockTheory-Paper.md
+++ b/Assignments/08-10_Compile-BufferStockTheory-Paper/Compile-BufferStockTheory-Paper.md
@@ -70,6 +70,6 @@ After the script has finished, you should test whether the setup is working:
 1. Change the name of the author of the paper to your own name, and `makeEverything` again
 
 1. Update the `BST-Public` local directory with the script:
-      `./makePublic.sh ~/Papers/BST/BST-Public update`
+      `./makePublic.sh ~/Papers/BST update`
 
 1. Incorporate the changes via `postEverything.sh`


### PR DESCRIPTION
I think there might be an underlying update in the makePublic.sh script. If you run that along with the path ~/Papers/BST/BST-Public, a separate BST-Shared folder is made within the BST/BST-Shared folder. This does not appear to happen if you just use the path ~/Papers/BST.